### PR TITLE
export typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "🚪 a wrapper for Tuya's OpenAPI",
   "main": "dist/api.js",
+  "types": "dist/api.d.ts",
   "files": [
     "dist/"
   ],

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,7 +8,7 @@ interface TuyaResponse {
   result: object;
 }
 
-class OpenAPI {
+export class OpenAPI {
   public tokenAccess: string;
   public tokenRefresh: string;
   public tokenExpiresAt: Date;


### PR DESCRIPTION
While working on https://github.com/TuyaAPI/link/issues/11 I figured out that this openapi library does not actually expose its typings.

This MR exports the OpenAPI class along with its typings.